### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["rexim <reximkut@gmail.com>"]
 
 [dependencies]
-glium = "*"
-glium_sdl2 = "*"
-sdl2 = "*"
+glium = "0.18"
+glium_sdl2 = "0.15"
+sdl2 = "0.30"


### PR DESCRIPTION
glium_sdl2 appears to be unmaintained now, it had a warning that it was under heavy development.
The readme says: `glium_sdl2 doesn't reexport the glium or sdl2 crates, so you must declare them with the versions listed above in your Cargo.toml file.` If we follow the readme, the project now compiles.